### PR TITLE
fix app:startDestination bug (start set to browse)

### DIFF
--- a/app/src/main/java/uk/co/sentinelweb/cuer/app/ui/browse/BrowseFragment.kt
+++ b/app/src/main/java/uk/co/sentinelweb/cuer/app/ui/browse/BrowseFragment.kt
@@ -4,17 +4,14 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
-import androidx.navigation.fragment.findNavController
-import androidx.navigation.ui.AppBarConfiguration
-import androidx.navigation.ui.setupWithNavController
 import kotlinx.android.synthetic.main.browse_fragment.*
 import org.koin.android.scope.currentScope
 import org.koin.android.viewmodel.dsl.viewModel
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import uk.co.sentinelweb.cuer.app.R
-import uk.co.sentinelweb.cuer.app.ui.main.MainActivity.Companion.TOP_LEVEL_DESTINATIONS
-
+// fixme : this is the app:startDestination fragment which causes a double instance and the menus not to work :/
+// when implemnenting here might need to make a dummy app:startDestination and  manually navigate in mainActivity
 class BrowseFragment : Fragment(R.layout.browse_fragment), BrowseContract.View {
 
     private val presenter: BrowseContract.Presenter by currentScope.inject()
@@ -28,7 +25,7 @@ class BrowseFragment : Fragment(R.layout.browse_fragment), BrowseContract.View {
         super.onViewCreated(view, savedInstanceState)
         browse_toolbar.let {
             (activity as AppCompatActivity).setSupportActionBar(it)
-            it.setupWithNavController(findNavController(), AppBarConfiguration(TOP_LEVEL_DESTINATIONS))
+            //it.setupWithNavController(findNavController(), AppBarConfiguration(TOP_LEVEL_DESTINATIONS))
         }
     }
 

--- a/app/src/main/java/uk/co/sentinelweb/cuer/app/ui/main/MainActivity.kt
+++ b/app/src/main/java/uk/co/sentinelweb/cuer/app/ui/main/MainActivity.kt
@@ -7,7 +7,7 @@ import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.bundleOf
 import androidx.navigation.NavController
-import androidx.navigation.findNavController
+import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
@@ -51,9 +51,12 @@ class MainActivity :
         super.onCreate(savedInstanceState)
         setContentView(R.layout.main_activity)
 
-        navController = findNavController(R.id.nav_host_fragment)
+//        navController = findNavController(R.id.nav_host_fragment)
+        val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment
+        val navController = navHostFragment.navController
         // setup nav draw https://developer.android.com/guide/navigation/navigation-ui#add_a_navigation_drawer
         bottom_nav_view.setupWithNavController(navController)
+        navController.navigate(R.id.navigation_playlist)
         presenter.initialise()
     }
 

--- a/app/src/main/java/uk/co/sentinelweb/cuer/app/ui/main/MainPresenter.kt
+++ b/app/src/main/java/uk/co/sentinelweb/cuer/app/ui/main/MainPresenter.kt
@@ -14,10 +14,13 @@ class MainPresenter(
     private val log: LogWrapper
 ) : MainContract.Presenter {
 
+    init {
+        log.tag(this)
+    }
+
     override fun initialise() {
-        log.tag = "MainPresenter"
-        playerControls.initMediaRouteButton()
-        playerControls.reset()
+
+
         if (!state.playServiceCheckDone) {
             view.checkPlayServices()
             state.playServiceCheckDone = true
@@ -42,6 +45,11 @@ class MainPresenter(
         ytServiceManager.stop()
         if (!ytContextHolder.isCreated() && state.playServicesAvailable) {
             initialiseCastContext()
+        }
+        if (!state.playControlsInit) {
+            playerControls.initMediaRouteButton()
+            playerControls.reset()
+            state.playControlsInit = true
         }
         ytContextHolder.playerUi = playerControls
     }

--- a/app/src/main/java/uk/co/sentinelweb/cuer/app/ui/main/MainState.kt
+++ b/app/src/main/java/uk/co/sentinelweb/cuer/app/ui/main/MainState.kt
@@ -4,5 +4,6 @@ import androidx.lifecycle.ViewModel
 
 data class MainState constructor(
     var playServicesAvailable: Boolean = false,
-    var playServiceCheckDone: Boolean = false
+    var playServiceCheckDone: Boolean = false,
+    var playControlsInit: Boolean = false
 ) : ViewModel()

--- a/app/src/main/java/uk/co/sentinelweb/cuer/app/ui/player/PlayerFragment.kt
+++ b/app/src/main/java/uk/co/sentinelweb/cuer/app/ui/player/PlayerFragment.kt
@@ -4,9 +4,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
-import androidx.navigation.fragment.findNavController
-import androidx.navigation.ui.AppBarConfiguration
-import androidx.navigation.ui.setupWithNavController
 import kotlinx.android.synthetic.main.player_fragment.*
 import org.koin.android.ext.android.inject
 import org.koin.android.scope.currentScope
@@ -14,7 +11,6 @@ import org.koin.android.viewmodel.dsl.viewModel
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import uk.co.sentinelweb.cuer.app.R
-import uk.co.sentinelweb.cuer.app.ui.main.MainActivity.Companion.TOP_LEVEL_DESTINATIONS
 import uk.co.sentinelweb.cuer.app.util.prefs.GeneralPreferences
 import uk.co.sentinelweb.cuer.app.util.prefs.SharedPrefsWrapper
 import uk.co.sentinelweb.cuer.app.util.wrapper.ToastWrapper
@@ -31,7 +27,7 @@ class PlayerFragment : Fragment(R.layout.player_fragment), PlayerContract.View {
         super.onViewCreated(view, savedInstanceState)
         player_toolbar.let {
             (activity as AppCompatActivity).setSupportActionBar(it)
-            it.setupWithNavController(findNavController(), AppBarConfiguration(TOP_LEVEL_DESTINATIONS))
+            //it.setupWithNavController(findNavController(), AppBarConfiguration(TOP_LEVEL_DESTINATIONS))
         }
 //        listFragment = childFragmentManager.findFragmentById(R.id.player_list_fragment)?.apply {
 //            arguments = bundleOf(

--- a/app/src/main/java/uk/co/sentinelweb/cuer/app/ui/playlist/PlaylistFragment.kt
+++ b/app/src/main/java/uk/co/sentinelweb/cuer/app/ui/playlist/PlaylistFragment.kt
@@ -10,8 +10,6 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
-import androidx.navigation.ui.AppBarConfiguration
-import androidx.navigation.ui.setupWithNavController
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
@@ -28,7 +26,6 @@ import uk.co.sentinelweb.cuer.app.ui.common.dialog.SelectDialogCreator
 import uk.co.sentinelweb.cuer.app.ui.common.dialog.SelectDialogModel
 import uk.co.sentinelweb.cuer.app.ui.common.item.ItemBaseContract
 import uk.co.sentinelweb.cuer.app.ui.common.navigation.NavigationModel.Param.*
-import uk.co.sentinelweb.cuer.app.ui.main.MainActivity.Companion.TOP_LEVEL_DESTINATIONS
 import uk.co.sentinelweb.cuer.app.ui.playlist.PlaylistContract.PlayState.*
 import uk.co.sentinelweb.cuer.app.ui.playlist.PlaylistContract.ScrollDirection.*
 import uk.co.sentinelweb.cuer.app.ui.playlist.item.ItemContract
@@ -48,7 +45,7 @@ import kotlin.math.max
 import kotlin.math.min
 
 class PlaylistFragment :
-    Fragment(R.layout.playlist_fragment),
+    Fragment(),
     PlaylistContract.View,
     ItemContract.Interactions,
     ItemBaseContract.ItemMoveInteractions {
@@ -84,11 +81,14 @@ class PlaylistFragment :
             binding.playlistToolbar.menu.findItem(R.id.playlist_mode_shuffle)
         )
 
-
     private var snackbar: Snackbar? = null
     private var createPlaylistDialog: DialogFragment? = null
 
     private var lastPlayModeIndex = 0
+
+    init {
+        log.tag(this)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -107,7 +107,7 @@ class PlaylistFragment :
         super.onViewCreated(view, savedInstanceState)
         binding.playlistToolbar.let {
             (activity as AppCompatActivity).setSupportActionBar(it)
-            it.setupWithNavController(findNavController(), AppBarConfiguration(TOP_LEVEL_DESTINATIONS))
+            //it.setupWithNavController(findNavController(), AppBarConfiguration(TOP_LEVEL_DESTINATIONS))
         }
         presenter.initialise()
         binding.playlistList.layoutManager = LinearLayoutManager(context)

--- a/app/src/main/java/uk/co/sentinelweb/cuer/app/ui/playlists/PlaylistsFragment.kt
+++ b/app/src/main/java/uk/co/sentinelweb/cuer/app/ui/playlists/PlaylistsFragment.kt
@@ -7,8 +7,6 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
-import androidx.navigation.ui.AppBarConfiguration
-import androidx.navigation.ui.setupWithNavController
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
@@ -19,11 +17,11 @@ import org.koin.android.ext.android.inject
 import org.koin.android.scope.currentScope
 import uk.co.sentinelweb.cuer.app.R
 import uk.co.sentinelweb.cuer.app.ui.common.item.ItemBaseContract
-import uk.co.sentinelweb.cuer.app.ui.main.MainActivity.Companion.TOP_LEVEL_DESTINATIONS
 import uk.co.sentinelweb.cuer.app.ui.playlists.item.ItemContract
 import uk.co.sentinelweb.cuer.app.util.firebase.FirebaseDefaultImageProvider
 import uk.co.sentinelweb.cuer.app.util.wrapper.SnackbarWrapper
 import uk.co.sentinelweb.cuer.app.util.wrapper.ToastWrapper
+import uk.co.sentinelweb.cuer.core.wrapper.LogWrapper
 
 class PlaylistsFragment :
     Fragment(R.layout.playlists_fragment),
@@ -37,20 +35,28 @@ class PlaylistsFragment :
     private val toastWrapper: ToastWrapper by inject()
     private val itemTouchHelper: ItemTouchHelper by currentScope.inject()
     private val imageProvider: FirebaseDefaultImageProvider by inject()
+    private val log: LogWrapper by inject()
 
     private var snackbar: Snackbar? = null
+
+    init {
+        log.tag(this)
+        log.d("${hashCode()} - init")
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
+        log.d("${hashCode()} - onCreate")
     }
 
     // region Fragment
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        log.d("${hashCode()} - onViewCreated")
         super.onViewCreated(view, savedInstanceState)
         playlists_toolbar.let {
             (activity as AppCompatActivity).setSupportActionBar(it)
-            it.setupWithNavController(findNavController(), AppBarConfiguration(TOP_LEVEL_DESTINATIONS))
+            //it.setupWithNavController(findNavController(), AppBarConfiguration(TOP_LEVEL_DESTINATIONS))
         }
 
         //presenter.initialise()
@@ -64,17 +70,24 @@ class PlaylistsFragment :
     }
 
     override fun onDestroyView() {
+        log.d("${hashCode()} - onDestroyView")
         presenter.destroy()
         super.onDestroyView()
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        log.d("${hashCode()} - onCreateOptionsMenu")
         super.onCreateOptionsMenu(menu, inflater)
     }
 
     override fun onResume() {
+        log.d("${hashCode()} - onResume")
         super.onResume()
         presenter.onResume()
+    }
+
+    override fun onPause() {
+        super.onPause()
     }
     // endregion
 

--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -18,7 +18,7 @@
         app:menu="@menu/bottom_nav"
         />
 
-    <fragment
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/nav_host_fragment"
         android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="match_parent"
@@ -30,7 +30,7 @@
         app:navGraph="@navigation/bottom_navigation"
         />
 
-    <fragment
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/cast_player_fragment"
         android:name="uk.co.sentinelweb.cuer.app.ui.play_control.CastPlayerFragment"
         android:layout_width="match_parent"

--- a/app/src/main/res/navigation/bottom_navigation.xml
+++ b/app/src/main/res/navigation/bottom_navigation.xml
@@ -4,8 +4,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/bottom_navigation"
-    app:startDestination="@id/navigation_playlist"
+    app:startDestination="@id/navigation_browse"
     >
+    <!--    Theres is a bug with app:startDestination that caused the specified fragment to use two instances when navigating -->
 
     <fragment
         android:id="@+id/navigation_browse"


### PR DESCRIPTION
This fixes a bug that stops the menu working for the PlaylistFragment

fix was to change `app:startDestination="@id/navigation_browse"` - might have to make a dummy fragment when broswe is built. 

There seem to be two instance of the start navigation gragment and onCreateenuItems is only called for the one that is not shown - so the menu items dont work

aslo disabled setting the top level nav options - app seems to be fine without it
https://developer.android.com/guide/navigation/navigation-ui